### PR TITLE
Update to use latest coreos-stream-metadata API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,8 @@ dependencies = [
  "serde_json",
  "smallvec",
  "structopt",
+ "strum",
+ "strum_macros",
  "tar",
  "tempfile",
  "tracing",
@@ -225,7 +227,7 @@ dependencies = [
 [[package]]
 name = "coreos-stream-metadata"
 version = "0.1.0"
-source = "git+https://github.com/cgwalters/stream-metadata-rust?rev=f23ee489a965ad4cc37ff549a75945c24aa0356a#f23ee489a965ad4cc37ff549a75945c24aa0356a"
+source = "git+https://github.com/coreos/stream-metadata-rust?rev=676fd60f218556a6b2ff913685e74ad6015c2b2c#676fd60f218556a6b2ff913685e74ad6015c2b2c"
 dependencies = [
  "anyhow",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,13 @@ serde_bytes = "0.11.5"
 serde_derive = "1.0.111"
 serde_json = "1.0"
 structopt = "0.3.21"
+strum = "0.20"
+strum_macros = "0.20"
 tempfile = "3.1.0"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"
 zstd = "0.7.0"
-coreos-stream-metadata = { git = "https://github.com/cgwalters/stream-metadata-rust", rev = "f23ee489a965ad4cc37ff549a75945c24aa0356a" }
+coreos-stream-metadata = { git = "https://github.com/coreos/stream-metadata-rust", rev = "676fd60f218556a6b2ff913685e74ad6015c2b2c" }
 nix = "0.20.0"
 rayon = "1.5.0"
 reqwest = { version = "0.11.3", "features" = ["blocking"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,14 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
 use tracing::{debug, info};
+use crate::streamid::stream_url_from_id;
 
 mod download;
 mod ova;
 mod qemu_img;
 mod riverdelta;
 mod rsync;
+mod streamid;
 mod utils;
 
 /// The target directory
@@ -136,7 +138,7 @@ fn run() -> Result<()> {
 
 /// Initialize directory with stream data
 fn build_init(stream: &str) -> Result<()> {
-    let u = coreos_stream_metadata::stream_url_from_id(stream)?;
+    let u = stream_url_from_id(stream)?;
     if Utf8Path::new(STREAM_FILE).exists() {
         return Err(anyhow!("{} exists, not overwriting", STREAM_FILE));
     }

--- a/src/streamid.rs
+++ b/src/streamid.rs
@@ -1,0 +1,68 @@
+use anyhow::{anyhow, Context, Result};
+use coreos_stream_metadata::{fcos, rhcos};
+use std::str::FromStr;
+use strum_macros::{Display, EnumString};
+
+/// The well-known distributions (operating systems) that generate
+/// stream metadata.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, EnumString, Display)]
+#[strum(serialize_all = "lowercase")]
+// Not `pub` right now, just used in `stream_url_from_id()`
+enum Distro {
+    /// Fedora CoreOS
+    FCOS,
+    /// Red Hat Enterprise Linux CoreOS
+    RHCOS,
+}
+
+/// Convert a string e.g. `fcos-stable` or `rhcos-4.8` to a stream URL.
+/// The format is `<distro>-<stream>`.
+pub(crate) fn stream_url_from_id(s: impl AsRef<str>) -> Result<String> {
+    let s = s.as_ref();
+    let mut it = s.splitn(2, '-');
+    let distro = it.next().unwrap();
+    let stream = it
+        .next()
+        .ok_or_else(|| anyhow!("Invalid stream ID, missing `-`: {}", s))?;
+    let distro =
+        Distro::from_str(distro).with_context(|| format!("Invalid distribution in {}", s))?;
+    Ok(match distro {
+        Distro::FCOS => fcos::StreamID::from_str(stream)
+            .with_context(|| format!("Invalid stream: {}", stream))?
+            .url(),
+        Distro::RHCOS => rhcos::StreamID::from_str(stream)
+            .with_context(|| format!("Invalid stream: {}", stream))?
+            .url(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stream_url() {
+        assert_eq!(
+            stream_url_from_id("fcos-stable").unwrap(),
+            fcos::StreamID::Stable.url()
+        );
+        assert_eq!(
+            stream_url_from_id("rhcos-4.8").unwrap(),
+            rhcos::StreamID::FourEight.url()
+        );
+
+        let invalid = &[
+            "",
+            "fcos",
+            "moo",
+            "rhcos",
+            "fcos-",
+            "-fcos",
+            "fcos-blah",
+            "fcos-blah-whee",
+        ];
+        for &elt in invalid {
+            assert!(stream_url_from_id(elt).is_err());
+        }
+    }
+}


### PR DESCRIPTION
This moves the "split stream from string" API to here for now.