### PR TITLE
download: Propagate HTTP errors

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -46,6 +46,7 @@ pub(crate) fn build_download() -> Result<()> {
                     let temp_name = &format!("{}.tmp", fname);
                     let mut out = std::io::BufWriter::new(File::create(temp_name)?);
                     let mut resp = client.get(location).send()?;
+                    resp.error_for_status_ref()?;
                     resp.copy_to(&mut out)
                         .with_context(|| anyhow!("Failed to download {}", location))?;
                     std::fs::rename(temp_name, fname)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![deny(unsafe_code)]
 
 use crate::riverdelta::{ArtifactExt, RiverDelta};
+use crate::streamid::stream_url_from_id;
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use coreos_stream_metadata::Artifact;
@@ -19,7 +20,6 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
 use tracing::{debug, info};
-use crate::streamid::stream_url_from_id;
 
 mod download;
 mod ova;
@@ -150,6 +150,7 @@ fn build_init(stream: &str) -> Result<()> {
             .open(STREAM_FILE)?,
     );
     let mut resp = reqwest::blocking::get(&u)?;
+    resp.error_for_status_ref()?;
     resp.copy_to(&mut out)?;
     out.flush()?;
     Ok(())


### PR DESCRIPTION
This should really, really be the default...